### PR TITLE
Corrected the min/max clamping in SpanValues

### DIFF
--- a/BC4BlockEncoder.cs
+++ b/BC4BlockEncoder.cs
@@ -182,8 +182,8 @@ namespace BCn
 			float vMin, vMax;
 			if( isSixPointInterp )
 			{
-				vMin = rangeMax;
-				vMax = rangeMin;
+				vMin = rangeMin;
+				vMax = rangeMax;
 
 				for( int i = 0; i < values.Length; i++ )
 				{


### PR DESCRIPTION
Corrected the min/max clamping in SpanValues for the BC4BlockEncoder.

This fixed an encoding bug I was running into with channel swapped images where pixels were turning solid because alpha was being ceiling'd.

Thanks a ton for this encoder!